### PR TITLE
chore: audit & align issue templates (#46)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,1 @@
 blank_issues_enabled: true
-contact_links:
-  - name: Report a security vulnerability
-    url: https://github.com/FiligranHQ/xtm-hub-docs/security/policy
-    about: Please review our security policy and report vulnerabilities privately and responsibly.
-  - name: Filigran community Slack
-    url: https://community.filigran.io
-    about: Ask questions and chat with the Filigran community.


### PR DESCRIPTION
Aligns `.github/ISSUE_TEMPLATE/` with the canonical Filigran template set (bug_report, feature_request, question, documentation) and switches `config.yml` to the public variant (`blank_issues_enabled: true` only). Native private vulnerability reporting is enabled, so the inline security contact link and the Filigran Slack link are removed.

Closes #46